### PR TITLE
Add LogTraces default for python module

### DIFF
--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -125,7 +125,8 @@
                 'postfix': ''
             },
             'python': {
-                'Globals': 'true'
+                'Globals': 'true',
+                'LogTraces': 'true'
             },
             'elasticsearch': {
             	'host': 'localhost',


### PR DESCRIPTION
Loading the python module will fail without LogTraces set in the
pillar since there is no default available. This change will set one.
