### PR TITLE
Add df percentages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,8 +270,9 @@ Enables and configures the write_riemann plugin, which outputs metric data to a 
 MOJ Notes
 =========
 
-``collectd.df``
-~~~~~~~~~~~~~~~
+collectd.df
+-----------
+
 Setting ValuesPercentage to default to show usage as percentages
 
 .. code:: yaml
@@ -284,3 +285,4 @@ Setting ValuesPercentage to default to show usage as percentages
                 'ReportInodes': 'false',
                 'ValuesPercentage': 'true'
             },
+

--- a/README.rst
+++ b/README.rst
@@ -266,3 +266,21 @@ Enables and configures the write_riemann plugin, which outputs metric data to a 
       port: 5555
       tag: "riemann"
 
+
+MOJ Notes
+=========
+
+``collectd.df``
+~~~~~~~~~~~~~~~
+Setting ValuesPercentage to default to show usage as percentages
+
+.. code:: yaml
+
+            'df': {
+                'Devices': [],
+                'IgnoreSelected': 'false',
+                'ReportByDevice': 'false',
+                'ReportReserved': 'false',
+                'ReportInodes': 'false',
+                'ValuesPercentage': 'true'
+            },

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -66,7 +66,7 @@
                 'ReportByDevice': 'false',
                 'ReportReserved': 'false',
                 'ReportInodes': 'false',
-                'ValuesPercentage': 'false'
+                'ValuesPercentage': 'true'
             },
             'disk': {
                 'matches': [],


### PR DESCRIPTION
Makes `collectd` produce the `df.<fs>.percent_bytes` metric.

I think this should be the default - it can also be enable on a project-by-project basis via the pillar in the `<project>-deploy` repo.

If merged, I will create a new revision and upgrade it in template-deploy.

![collect_percent_bytes](https://cloud.githubusercontent.com/assets/7428118/12394391/75c6be80-bdf3-11e5-8403-faee60569dc2.png)
