### PR TITLE
Custom Java JMX conf

### DIFF
--- a/collectd/files/java.conf
+++ b/collectd/files/java.conf
@@ -10,116 +10,21 @@
 LoadPlugin java
 
 <Plugin "java">
+  # required JVM argument is the classpath
+  # JVMArg "-Djava.class.path=/installpath/collectd/share/collectd/java"
+  # Since version 4.8.4 (commit c983405) the API and GenericJMX plugin are
+  # provided as .jar files.
+  JVMARG "-Djava.class.path=/usr/share/collectd/java/collectd-api.jar:/usr/share/collectd/java/generic-jmx.jar"
   LoadPlugin "org.collectd.java.GenericJMX"
 
   <Plugin "GenericJMX">
-    ################
-    # MBean blocks #
-    ################
-    # Number of classes being loaded.
-    <MBean "classes">
-      ObjectName "java.lang:type=ClassLoading"
-      #InstancePrefix ""
-      #InstanceFrom ""
-
-      <Value>
-        Type "gauge"
-        InstancePrefix "loaded_classes"
-        #InstanceFrom ""
-        Table false
-        Attribute "LoadedClassCount"
-      </Value>
-    </MBean>
-
-    # Time spent by the JVM compiling or optimizing.
-    <MBean "compilation">
-      ObjectName "java.lang:type=Compilation"
-      #InstancePrefix ""
-      #InstanceFrom ""
-
-      <Value>
-        Type "total_time_in_ms"
-        InstancePrefix "compilation_time"
-        #InstanceFrom ""
-        Table false
-        Attribute "TotalCompilationTime"
-      </Value>
-    </MBean>
-
-    # Garbage collector information
-    <MBean "garbage_collector">
-      ObjectName "java.lang:type=GarbageCollector,*"
-      InstancePrefix "gc-"
-      InstanceFrom "name"
-
-      <Value>
-        Type "invocations"
-        #InstancePrefix ""
-        #InstanceFrom ""
-        Table false
-        Attribute "CollectionCount"
-      </Value>
-
-      <Value>
-        Type "total_time_in_ms"
-        InstancePrefix "collection_time"
-        #InstanceFrom ""
-        Table false
-        Attribute "CollectionTime"
-      </Value>
-
-#      # Not that useful, therefore commented out.
-#      <Value>
-#        Type "threads"
-#        #InstancePrefix ""
-#        #InstanceFrom ""
-#        Table false
-#        # Demonstration how to access composite types
-#        Attribute "LastGcInfo.GcThreadCount"
-#      </Value>
-    </MBean>
-
-    ######################################
-    # Define the "jmx_memory" type as:   #
-    #   jmx_memory  value:GAUGE:0:U      #
-    # See types.db(5) for details.       #
-    ######################################
-
-    # Generic heap/nonheap memory usage.
-    <MBean "memory">
-      ObjectName "java.lang:type=Memory"
-      #InstanceFrom ""
-      InstancePrefix "memory"
-
-      # Creates four values: committed, init, max, used
-      <Value>
-        Type "jmx_memory"
-        #InstancePrefix ""
-        #InstanceFrom ""
-        Table true
-        Attribute "HeapMemoryUsage"
-        InstancePrefix "heap-"
-      </Value>
-
-      # Creates four values: committed, init, max, used
-      <Value>
-        Type "jmx_memory"
-        #InstancePrefix ""
-        #InstanceFrom ""
-        Table true
-        Attribute "NonHeapMemoryUsage"
-        InstancePrefix "nonheap-"
-      </Value>
-    </MBean>
-
     # Memory usage by memory pool.
     <MBean "memory_pool">
       ObjectName "java.lang:type=MemoryPool,*"
       InstancePrefix "memory_pool-"
       InstanceFrom "name"
-
       <Value>
-        Type "jmx_memory"
+        Type "memory"
         #InstancePrefix ""
         #InstanceFrom ""
         Table true
@@ -127,91 +32,66 @@ LoadPlugin java
       </Value>
     </MBean>
 
-    ### MBeans by Catalina / Tomcat ###
-    # The global request processor (summary for each request processor)
-    <MBean "catalina/global_request_processor">
-      ObjectName "Catalina:type=GlobalRequestProcessor,*"
-      InstancePrefix "request_processor-"
+    <MBean "garbage_collector">
+      ObjectName "java.lang:type=GarbageCollector,*"
+      InstancePrefix "gc-"
       InstanceFrom "name"
-
+  
       <Value>
-        Type "io_octets"
-        InstancePrefix "global"
+        Type "invocations"
+        #InstancePrefix ""
         #InstanceFrom ""
         Table false
-        Attribute "bytesReceived"
-        Attribute "bytesSent"
+        Attribute "CollectionCount"
       </Value>
-
-      <Value>
-        Type "total_requests"
-        InstancePrefix "global"
-        #InstanceFrom ""
-        Table false
-        Attribute "requestCount"
-      </Value>
-
+  
       <Value>
         Type "total_time_in_ms"
-        InstancePrefix "global-processing"
+        InstancePrefix "collection_time"
         #InstanceFrom ""
         Table false
-        Attribute "processingTime"
+        Attribute "CollectionTime"
+      </Value>
+  
+    # # Not that useful, therefore commented out.
+    # <Value>
+    #   Type "threads"
+    #   #InstancePrefix ""
+    #   #InstanceFrom ""
+    #   Table false
+    #   # Demonstration how to access composite types
+    #   Attribute "LastGcInfo.GcThreadCount"
+    # </Value>
+    </MBean>
+
+    # Heap memory usage
+    <MBean "memory-heap">
+      ObjectName "java.lang:type=Memory"
+      #InstanceFrom ""
+      InstancePrefix "memory-heap"
+  
+      # Creates four values: committed, init, max, used
+      <Value>
+        Type "jmx_memory"  
+        #InstancePrefix ""
+        #InstanceFrom ""
+        Table true
+        Attribute "HeapMemoryUsage"
       </Value>
     </MBean>
 
-    # Details for each  request processor
-    <MBean "catalina/detailed_request_processor">
-      ObjectName "Catalina:type=RequestProcessor,*"
-      InstancePrefix "request_processor-"
-      InstanceFrom "worker"
-
+    # Non-heap memory usage
+    <MBean "memory-nonheap">
+      ObjectName "java.lang:type=Memory"
+      #InstanceFrom ""
+      InstancePrefix "memory-nonheap"
+      # Creates four values: committed, init, max, used
       <Value>
-        Type "io_octets"
+        Type "jmx_memory"  
         #InstancePrefix ""
-        InstanceFrom "name"
-        Table false
-        Attribute "bytesReceived"
-        Attribute "bytesSent"
-      </Value>
-
-      <Value>
-        Type "total_requests"
-        #InstancePrefix ""
-        InstanceFrom "name"
-        Table false
-        Attribute "requestCount"
-      </Value>
-
-      <Value>
-        Type "total_time_in_ms"
-        InstancePrefix "processing-"
-        InstanceFrom "name"
-        Table false
-        Attribute "processingTime"
-      </Value>
-    </MBean>
-
-    # Thread pool
-    <MBean "catalina/thread_pool">
-      ObjectName "Catalina:type=ThreadPool,*"
-      InstancePrefix "request_processor-"
-      InstanceFrom "name"
-
-      <Value>
-        Type "threads"
-        InstancePrefix "total"
         #InstanceFrom ""
-        Table false
-        Attribute "currentThreadCount"
-      </Value>
-
-      <Value>
-        Type "threads"
-        InstancePrefix "running"
-        #InstanceFrom ""
-        Table false
-        Attribute "currentThreadsBusy"
+        Table true
+        Attribute "NonHeapMemoryUsage"
       </Value>
     </MBean>
 
@@ -227,11 +107,12 @@ LoadPlugin java
       Password "{{ pass }}"
 {%- endif %}
       Host "{{ collectd_settings.plugins.java.host }}"
+      Collect "memory_pool"
       Collect "classes"
       Collect "compilation"
       Collect "garbage_collector"
-      Collect "memory"
-      Collect "memory_pool"
+      Collect "memory-heap"
+      Collect "memory-nonheap"
     </Connection>
   </Plugin>
 </Plugin>

--- a/collectd/files/java.conf
+++ b/collectd/files/java.conf
@@ -36,7 +36,6 @@ LoadPlugin java
       ObjectName "java.lang:type=GarbageCollector,*"
       InstancePrefix "gc-"
       InstanceFrom "name"
-  
       <Value>
         Type "invocations"
         #InstancePrefix ""
@@ -44,7 +43,6 @@ LoadPlugin java
         Table false
         Attribute "CollectionCount"
       </Value>
-  
       <Value>
         Type "total_time_in_ms"
         InstancePrefix "collection_time"
@@ -52,7 +50,6 @@ LoadPlugin java
         Table false
         Attribute "CollectionTime"
       </Value>
-  
     # # Not that useful, therefore commented out.
     # <Value>
     #   Type "threads"
@@ -72,7 +69,7 @@ LoadPlugin java
   
       # Creates four values: committed, init, max, used
       <Value>
-        Type "jmx_memory"  
+        Type "jmx_memory"
         #InstancePrefix ""
         #InstanceFrom ""
         Table true

--- a/collectd/java.sls
+++ b/collectd/java.sls
@@ -10,11 +10,12 @@ collectd-java:
         - force: False
         - makedirs: False
 
-{{ collectd_settings.javalib }}:
+{% if collectd_settings.plugins.java.lib is defined and collectd_settings.plugins.java.lib %}
+collectd_settings.javalib }}:
     file.symlink:
         - target: {{ collectd_settings.plugins.java.lib }}
         - makedirs: False
-
+{% endif %}
 
 {{ collectd_settings.plugindirconfig }}/java.conf:
   file.managed:


### PR DESCRIPTION
- in `java.sls`:
  The state is executed only if the `collectd.plugins.java.lib` value exists in the pillar.
  This state seems to be unnecessary, it is not clear what was the aim behind it and it breaks in our environment (if `lib` is not present, the highstate fails; if it's present it fails because the target file already exists)
- in `collectd/files/java.conf`:
  Removed the Catalina MBeans entries as they are not relevant for our environment.

This change has been extensively tested and it should be safe.
