### PR TITLE
Removed 2 offending lines which break the plugin

### DIFF
--- a/collectd/files/java.conf
+++ b/collectd/files/java.conf
@@ -105,8 +105,6 @@ LoadPlugin java
 {%- endif %}
       Host "{{ collectd_settings.plugins.java.host }}"
       Collect "memory_pool"
-      Collect "classes"
-      Collect "compilation"
       Collect "garbage_collector"
       Collect "memory-heap"
       Collect "memory-nonheap"


### PR DESCRIPTION
I forgot to remove these 2 lines.
I knew from my tests that they broke the plugin, unfortunately I forgot to remove them.
One final test after the previous PR has brought them out again.
