### PR TITLE
Always upgrade elasticsearch plugin

### DIFF
--- a/collectd/elasticsearch.sls
+++ b/collectd/elasticsearch.sls
@@ -7,6 +7,7 @@ include:
 collectd-elasticsearch-module:
   pip.installed:
   - name: git+https://github.com/ministryofjustice/elasticsearch-collectd-plugin
+  - upgrade: True
   - require_in:
     - service: collectd
   - watch_in:


### PR DESCRIPTION
We ensure the elasticsearch plugin for collectd is installed through
a git repo link. This means that, if it is already installed, we dont
get any updates. This change makes the default to install any upgrade
to the collectd elasticsearch plugin. This makes sense as we already
only specify master by default as the installation source.
