### PR TITLE
Always upgrade redis plugin

### DIFF
--- a/collectd/redis_info.sls
+++ b/collectd/redis_info.sls
@@ -7,6 +7,7 @@ include:
 collectd-redis-module:
   pip.installed:
   - name: git+https://github.com/ministryofjustice/redis-collectd-plugin@make-it-a-pip
+  - upgrade: True
   - require_in:
     - service: collectd
   - watch_in:


### PR DESCRIPTION
We ensure the redis plugin for collectd is installed through
a git repo link. This means that, if it is already installed, we dont
get any updates. This change makes the default to install any upgrade
to the collectd redis plugin. This makes sense as we already
only specify master by default as the installation source.
