### PR TITLE
Set default key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,11 @@ Contents
 Usage
 -----
 
+.. note::
+
+    The formula sets common defaults so in most cases will only require the 
+    states to be loaded in the top.sls file.
+
 Custom state file
 ~~~~~~~~~~~~~~~~~
 

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -1,3 +1,6 @@
+{% set application=salt['grains.get']('Application', 'unknown') %}
+{% set env=salt['grains.get']('Env', 'unknown') %}
+
 {% set os_map = salt['grains.filter_by']({
     'Debian': {
         'config': '/etc/collectd/collectd.conf',
@@ -126,7 +129,7 @@
             'write_graphite': {
                 'host': salt['grains.get']('fqdn'),
                 'port': 2003,
-                'prefix': 'collectd',
+                'prefix': 'collectd.' + application,
                 'postfix': ''
             },
             'write_riemann': {


### PR DESCRIPTION
By setting a default for the collectd prefix we can utilise the formula
with sane defaults simply by loading the desired state files.